### PR TITLE
Feature 01 - 1 error context with 'nelson --wtf'

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -30,7 +30,7 @@ for arg in "$@"; do
             LAST_COMMAND=$(tail -n 2 "$HISTFILE" | head -n 1 | sed 's/.*;//' )
 
             if [ "$ASK_WTF_CONFIRMATION" = "true" ]; then
-                read -p "Warning: this will run the last command: '$LAST_COMMAND' again. Do you wish to continue? (y/n) >> " response
+                read -p "Warning: this will run the last command: '$LAST_COMMAND' again. Do you wish to continue? (this alert can be disabled in settings) (y/n) >> " response
 
                 if [ "$response" != "y" ] && [ "$response" != "Y" ]; then
                     echo "Aborting..."
@@ -38,10 +38,11 @@ for arg in "$@"; do
                 else 
                     echo "Running '$LAST_COMMAND' and evaluating the result."
                 fi
+            else
+               echo "Running '$LAST_COMMAND' and evaluating the result."
             fi
 
             MODE="wtf"
-
             ;;
 
         --debug)

--- a/settings.sh
+++ b/settings.sh
@@ -13,11 +13,18 @@ export OUTPUT_DISPLAYER="bat --style grid --paging=never --language md"
 # export OUTPUT_DISPLAYER="cat"
 
 export SHOW_DEBUG_INFO=false
+
+# ----- --wtf -----
+
+# because we're using bash to run the script, it might be different than your main zsh or fish $HISTFILE (I think)
+# run 'echo $HISTFILE' in your main shell to get the location. 
 export HISTFILE="/Users/vicente.figueiredo/.zhistory"
+export ASK_WTF_CONFIRMATION=true
+export SHOW_COMMAND_BEFORE_WTF_RESPONSE=false
 
 # Logging
 export OUTPUT_FILE="$NELSON_LOCATION/output.log"
-export LOG_MODE="never" # "never" / "one" / "always"
+export LOG_MODE="one" # "never" / "one" / "always"
 
 # flags
 export USE_DEFAULT_ON_SYSTEM_PROMPT_FLAG_ERROR=false

--- a/settings.sh
+++ b/settings.sh
@@ -13,6 +13,7 @@ export OUTPUT_DISPLAYER="bat --style grid --paging=never --language md"
 # export OUTPUT_DISPLAYER="cat"
 
 export SHOW_DEBUG_INFO=false
+export HISTFILE="/Users/vicente.figueiredo/.zhistory"
 
 # Logging
 export OUTPUT_FILE="$NELSON_LOCATION/output.log"

--- a/system_prompts.sh
+++ b/system_prompts.sh
@@ -6,6 +6,9 @@ get_system_prompt() {
         default)
             echo "$DEFAULT_SYSTEM_PROMPT"
             ;;
+        wtf)
+            echo "You are a Unix Command Line expert. You know the normal Unix commands, aswell as all the available tools that have been developed over the years. You also know all about errors, and can give context, debug help, and responses to errors that are given to you. "
+            ;;
         neat)
             echo "You are a Unix Command Line expert. You know the normal Unix commands, aswell as all the available tools that have been developed over the years. You are a concise responder. You always respond in a very concise manner, using concise language."
             ;;


### PR DESCRIPTION
You can now use `nelson --wtf` to get info on the previous command run. Useful when a command you run doesn't work as intended and gives an error.

Warning: `nelson --wtf` reruns the last command. There is an in-line prompt when you run the script, but this can be omitted in settings.

You can also enable re-writing the command output to the terminal. 
